### PR TITLE
[TASK] Keep original index page of Fluid ViewHelpers documentation

### DIFF
--- a/.github/workflows/fluid-viewhelper.yml
+++ b/.github/workflows/fluid-viewhelper.yml
@@ -74,11 +74,13 @@ jobs:
 
       - name: Update repository
         working-directory: ./viewhelpers
-        # fails if there are no changes
+        # - fails if there are no changes
+        # - keep original Documentation/Index.rst
         continue-on-error: true
         run: |
           rm -rf Documentation/typo3 Documentation/typo3fluid
           cp -r ../documentation/* Documentation/
+          git reset --hard Documentation/Index.rst
           git config user.name "TYPO3 Documentation Team"
           git config user.email "documentation-automation@typo3.com"
           git add .


### PR DESCRIPTION
It corresponds to the TYPO3 Documentation Standards and should
not be overwritten by the generated index page.