### PR TITLE
[TASK] Use PHP 8.2 for  ViewHelper Generation

### DIFF
--- a/.github/workflows/fluid-viewhelper.yml
+++ b/.github/workflows/fluid-viewhelper.yml
@@ -16,11 +16,11 @@ jobs:
       TARGET_PATH: ${{ secrets.API_TARGET_PATH }}/${{ matrix.core }}
     steps:
 
-      - name: Setup PHP 8.1
+      - name: Setup PHP 8.2
         if: matrix.core == 'main'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - name: Checkout Fluid Documentation Generator
         uses: actions/checkout@v2


### PR DESCRIPTION
typo3 dev-main dropped PHP 8.2  therefore the workflows fail