### PR TITLE
[TASK] Increase deploy job timeout for main rendering

### DIFF
--- a/.github/workflows/main-rendering.yml
+++ b/.github/workflows/main-rendering.yml
@@ -52,6 +52,7 @@ jobs:
     name: Deploy ${{ github.event.client_payload.vendor }}/${{ github.event.client_payload.name }}
     needs: render
     if: ${{ github.event.client_payload.type_short != '' && github.event.client_payload.vendor != '' && github.event.client_payload.name != '' && github.event.client_payload.target_branch_directory != ''}}
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This commit sets the default timeout for the `deploy` job for the `Main Rendering` action to `20` minutes  to avoid timeouts while rendering documentation with a lot of files and content.

Fixes: #28