### PR TITLE
[TASK] Set command_timeout to 20m for the Update search data step

### DIFF
--- a/.github/workflows/main-rendering.yml
+++ b/.github/workflows/main-rendering.yml
@@ -52,7 +52,6 @@ jobs:
     name: Deploy ${{ github.event.client_payload.vendor }}/${{ github.event.client_payload.name }}
     needs: render
     if: ${{ github.event.client_payload.type_short != '' && github.event.client_payload.vendor != '' && github.event.client_payload.name != '' && github.event.client_payload.target_branch_directory != ''}}
-    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -87,6 +86,7 @@ jobs:
           host: ${{ secrets.DEPLOY_DOCS_HOST }}
           username: ${{ secrets.DEPLOY_DOCS_USERNAME }}
           key: ${{ secrets.DEPLOY_KEY }}
+          command_timeout: 20m
           script: |
             export APP_ENV=prod
             export APP_SECRET=${{ secrets.DOC_SEARCH_APP_SECRET }}


### PR DESCRIPTION
The appleboy/ssh-action by default has command_timeout set to `10m` which might be not enough for our docs indexing. This commit increases it to `20m`.

This commit also removes previously set `timeout-minutes=20` for the `Deploy` job
since GutHub has it set to 360 by default.