### PR TITLE
[TASK] Only add new ViewHelper documentation files if they do not exist

### DIFF
--- a/.github/workflows/fluid-viewhelper.yml
+++ b/.github/workflows/fluid-viewhelper.yml
@@ -43,15 +43,10 @@ jobs:
         working-directory: ./viewhelpers
         continue-on-error: true
         run: |
-          for file in ../documentation/*; do
-            target_file="Documentation/$(basename "$file")"
-            if [ ! -f "$target_file" ]; then
-              cp -r "$file" Documentation/
-            fi
-          done
+          rsync -av --ignore-existing ../documentation/ Documentation/
           git checkout HEAD -- Documentation/Index.rst
           git config user.name "TYPO3 Documentation Team"
           git config user.email "documentation-automation@typo3.com"
           git add .
-          git commit -m '[BOT][TASK] Automatic Update of ViewHelper reference' || echo "No changes to commit"
+          git commit -m '[BOT][TASK] Only add new ViewHelper documentation files' || echo "No changes to commit"
           git push

--- a/.github/workflows/fluid-viewhelper.yml
+++ b/.github/workflows/fluid-viewhelper.yml
@@ -41,14 +41,17 @@ jobs:
 
       - name: Update repository
         working-directory: ./viewhelpers
-        # - fails if there are no changes
-        # - keep original Documentation/Index.rst
         continue-on-error: true
         run: |
-          cp -rf ../documentation/* Documentation/
+          for file in ../documentation/*; do
+            target_file="Documentation/$(basename "$file")"
+            if [ ! -f "$target_file" ]; then
+              cp -r "$file" Documentation/
+            fi
+          done
           git checkout HEAD -- Documentation/Index.rst
           git config user.name "TYPO3 Documentation Team"
           git config user.email "documentation-automation@typo3.com"
           git add .
-          git commit -m '[BOT][TASK] Automatic Update of ViewHelper reference'
+          git commit -m '[BOT][TASK] Automatic Update of ViewHelper reference' || echo "No changes to commit"
           git push


### PR DESCRIPTION
This change ensures that existing files in the ViewHelper documentation are not overwritten when updating the repository. Only new files are copied, preventing unintended modifications to previously committed documentation.

Additionally, the commit step is skipped if no new files are added, avoiding unnecessary empty commits.