### PR TITLE
[FIX] remove legacy action from workflow

### DIFF
--- a/.github/workflows/main-rendering.yml
+++ b/.github/workflows/main-rendering.yml
@@ -17,27 +17,164 @@ jobs:
           webhook_secret: ${{ secrets.WEBHOOK_SECRET }}
           data: '{"success":false,"id":"${{ github.event.client_payload.id }}","link":"https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/${{ github.run_id }}"}'
 
-      # See https://github.com/TYPO3-Documentation/gh-render-action/blob/main/action.yml
-      - name: Render Repository
-        uses: TYPO3-Documentation/gh-render-action@8469606ccb95c20d049f5d3222d74acf5523edbd
-        id: rendering
-        with:
-          repository_url: ${{ github.event.client_payload.repository_url }}
-          source_branch: ${{ github.event.client_payload.source_branch }}
-          target_branch_directory: ${{ github.event.client_payload.target_branch_directory }}
-
-      - name: Archive render result
+      - name: Checkout project repository
+        shell: bash
         run: |
-          pushd ${{ steps.rendering.outputs.renderedPath }}
-          zip rendered-docs.zip . -r
-          popd
-          mv ${{ steps.rendering.outputs.renderedPath }}/rendered-docs.zip .
+          git clone --depth 1 ${{ github.event.client_payload.repository_url }} -b ${{ github.event.client_payload.source_branch }} ${{ github.workspace }}/t3docsproject
+
+      - id: enable_guides
+        working-directory: ${{ github.workspace }}/t3docsproject
+        shell: bash
+        run: |
+          if [[ -f Documentation/settings.cfg && ! -f Documentation/guides.xml ]]; then
+            echo "MIGRATED=false" >> $GITHUB_OUTPUT
+          else
+            echo "MIGRATED=true" >> $GITHUB_OUTPUT
+          fi
+
+      - id: pre-render-guides
+        working-directory: ${{ github.workspace }}/t3docsproject
+        shell: bash
+        run: mkdir -p RenderedDocumentation/Result/project/0.0.0
+
+      - id: migrate
+        if: steps.enable_guides.outputs.MIGRATED == 'false' && hashFiles('Documentation/settings.cfg') != ''
+        shell: bash
+        working-directory: ${{ github.workspace }}/t3docsproject
+        run: |
+          echo "::warning file=Documentation/settings.cfg,line=1,title=Please migrate::Forced migration activated. Your project is not yet using the PHP-based rendering, please properly migrate: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Howto/Migration/Index.html"
+          
+          # Run migration, but do not exit on failure
+          if ! docker run --rm --user=$(id -u):$(id -g) \
+            --pull always \
+            -v $(pwd):/project \
+            ghcr.io/typo3-documentation/render-guides:latest \
+              migrate Documentation; then
+            echo "::warning::Migration failed, but continuing with the workflow..."
+          fi
+
+      - uses: TYPO3-Documentation/render-guides@main
+        id: render-guides
+        with:
+          working-directory: ${{ github.workspace }}/t3docsproject
+          config: ${{ github.workspace }}/t3docsproject/Documentation/
+          output: ./RenderedDocumentation/Result/project/0.0.0
+          configure-branch: ${{ env.source_branch }}
+          configure-project-release: ${{ env.target_branch_directory }}
+          configure-project-version: ${{ env.target_branch_directory }}
+
+      - id: render-guides-localization
+        shell: bash
+        working-directory: ${{ github.workspace }}/t3docsproject
+        run: |
+          echo "::group::Prepare move of possible localizations by render-guides"
+          
+          # "render-guides" uses a different directory structure than sphinx did.
+          # Sphinx puts localizations OUTSIDE the main 0.0.0 directory tree, using "xx-yy"
+          # render-guides puts localizations WITHIN the main 0.0.0 directory tree, and
+          #               uses "Localization.xx_YY" directory names
+          
+          # This step harmonizes that to the expected sphinx directory structure.
+          
+          # Expected directory structure BEFORE:
+          # RenderedDocumentation/Result/project/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Sub/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Localization.de_DE/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Localization.de_DE/Sub/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Localization.ru_RU/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Localization.ru_RU/Sub/Index.html
+
+          # Expected directory structure AFTER:
+          # RenderedDocumentation/Result/project/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Sub/Index.html
+          # RenderedDocumentation/Result/project/de-de/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/de-de/0.0.0/Sub/Index.html
+          # RenderedDocumentation/Result/project/ru-ru/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/ru-ru/0.0.0/Sub/Index.html
+
+          projectBaseDirectory="RenderedDocumentation/Result/project/0.0.0/"
+          if [ -d $projectBaseDirectory ]; then
+                  currentWorkingDir=$(pwd)
+                  cd $projectBaseDirectory
+                  for localizationDirectory in Localization.*; do
+                          echo "$localizationDirectory check..."
+                          if [[ -d $localizationDirectory ]]; then
+                                  sub_dir_name=$(echo "$localizationDirectory" | sed 's/Localization.//' | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+                                  echo "  Operating on $sub_dir_name"
+                                  # Check if the subdirectory name matches the required pattern
+                                  if [[ $sub_dir_name =~ ^[a-z]+-[a-z]+$ ]]; then
+                                          # Move something like:
+                                          # > RenderedDocumentation/Result/project/0.0.0/Localization.ru_RU/
+                                          # to
+                                          # > RenderedDocumentation/Result/project/ru_RU/0.0.0
+                                          # This will allow further processing in the next steps.
+                                          echo "    Move $localizationDirectory to ../$sub_dir_name/0.0.0"
+                                          mkdir -p "../$sub_dir_name"
+                                          mv "$localizationDirectory" "../$sub_dir_name/0.0.0"
+                                  else
+                                          echo "    Invalid localization."
+                                  fi
+                          else
+                              echo "  Not a directory."
+                          fi
+                  done
+                  cd $currentWorkingDir
+          fi
+          echo "::endgroup::"
+
+      - id: langhandling
+        shell: bash
+        working-directory: ${{ github.workspace }}/t3docsproject
+        run: |
+          echo "::group::Prepare final structure"
+
+          # Expected directory structure BEFORE:
+          # RenderedDocumentation/Result/project/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/0.0.0/Sub/Index.html
+          # RenderedDocumentation/Result/project/de-de/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/de-de/0.0.0/Sub/Index.html
+          # RenderedDocumentation/Result/project/ru-ru/0.0.0/Index.html
+          # RenderedDocumentation/Result/project/ru-ru/0.0.0/Sub/Index.html
+
+          # Expected directory structure AFTER:
+          # FinalDocumentation/en-us/Index.html
+          # FinalDocumentation/en-us/Sub/Index.html
+          # FinalDocumentation/de-de/Index.html
+          # FinalDocumentation/de-de/Sub/Index.html
+          # FinalDocumentation/ru-ru/Index.html
+          # FinalDocumentation/ru-ru/Sub/Index.html
+
+          # if a result has been rendered for the main directory, we treat that as the 'en_us' version
+          if [ -d RenderedDocumentation/Result/project/0.0.0/ ]; then
+                  echo "Handling main doc result as en-us version"
+                  mkdir -p FinalDocumentation/en-us
+                  # Move en-us files to target dir, including dot files
+                  (shopt -s dotglob; mv RenderedDocumentation/Result/project/0.0.0/* FinalDocumentation/en-us)
+                  # Remove the directory, all content has been moved
+                  rmdir RenderedDocumentation/Result/project/0.0.0/
+                  # Remove a possibly existing Localization.en_us directory, if it exists
+                  rm -rf RenderedDocumentation/Result/project/en-us/
+          fi
+
+          # now see if other localization versions have been rendered. if so, move them to FinalDocumentation/, too
+          if [ "$(ls -A RenderedDocumentation/Result/project/)" ]; then
+              for LOCALIZATIONDIR in RenderedDocumentation/Result/project/*; do
+                      LOCALIZATION=`basename $LOCALIZATIONDIR`
+                      echo "Handling localized documentation version ${LOCALIZATION:?Localization could not be determined}"
+                      mkdir FinalDocumentation/${LOCALIZATION}
+                      (shopt -s dotglob; mv ${LOCALIZATIONDIR}/0.0.0/* FinalDocumentation/${LOCALIZATION})
+                      # Remove the localization dir, it should be empty now
+                      rmdir ${LOCALIZATIONDIR}/0.0.0/
+                      rmdir ${LOCALIZATIONDIR}
+              done
+          fi
+          echo "::endgroup::"
 
       - name: Publish archive with result
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: result
-          path: rendered-docs.zip
+          path: ${{ github.workspace }}/t3docsproject/FinalDocumentation/
           if-no-files-found: error
 
       - name: Notify on failure


### PR DESCRIPTION
The gh-render-action is not maintained, and should not be used by anyone. This is a first step to remove the legacy we have in this render workflow. By moving everything into one repository we will have a better insight on how to refactor and improve the worflows.