### PR TITLE
[TASK] Add reusable CI workflows for TYPO3-Documentation repos

### DIFF
--- a/.github/workflows/reusable-backport.yml
+++ b/.github/workflows/reusable-backport.yml
@@ -1,0 +1,26 @@
+name: Backport
+on:
+  workflow_call:
+    inputs:
+      label-pattern:
+        description: 'Label pattern for backport branches (e.g. "backport *")'
+        type: string
+        default: 'backport *'
+
+jobs:
+  backport:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Backport
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.merged == true &&
+      contains(toJson(github.event.pull_request.labels), 'backport')
+    steps:
+      - name: Backport
+        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
+        with:
+          label_pattern: "${{ inputs.label-pattern }}"
+          merge_method: "none"

--- a/.github/workflows/reusable-docs-render.yml
+++ b/.github/workflows/reusable-docs-render.yml
@@ -1,0 +1,33 @@
+name: Documentation Rendering
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'Python version'
+        type: string
+        default: '3.12'
+
+jobs:
+  render:
+    permissions:
+      contents: read
+    name: Render Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "${{ inputs.python-version }}"
+
+      - name: Render documentation
+        run: |
+          if [ -f "composer.json" ] && grep -q "typo3/guides-cli" composer.json; then
+            composer install --no-interaction --no-progress --prefer-dist
+            vendor/bin/guides --no-progress Documentation
+          else
+            pip install typo3-docs-theme
+            typo3-docs-theme render Documentation
+          fi

--- a/.github/workflows/reusable-php-quality.yml
+++ b/.github/workflows/reusable-php-quality.yml
@@ -1,0 +1,89 @@
+name: PHP Quality
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: 'PHP version for quality checks'
+        type: string
+        default: '8.2'
+      run-cs-fixer:
+        description: 'Run PHP CS Fixer'
+        type: boolean
+        default: true
+      cs-fixer-command:
+        description: 'CS Fixer command'
+        type: string
+        default: 'make test-cs-fixer'
+      run-phpstan:
+        description: 'Run PHPStan'
+        type: boolean
+        default: true
+      phpstan-command:
+        description: 'PHPStan command'
+        type: string
+        default: 'make test-phpstan'
+      run-xml-lint:
+        description: 'Run XML lint'
+        type: boolean
+        default: false
+      xml-lint-command:
+        description: 'XML lint command'
+        type: string
+        default: 'make test-xml-lint'
+      php-extensions:
+        description: 'PHP extensions to install'
+        type: string
+        default: ''
+      run-environment:
+        description: 'RUN_ENVIRONMENT value'
+        type: string
+        default: 'local'
+
+jobs:
+  quality:
+    permissions:
+      contents: read
+    name: Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        with:
+          coverage: none
+          php-version: "${{ inputs.php-version }}"
+          extensions: "${{ inputs.php-extensions }}"
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ inputs.php-version }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: PHP CS Fixer
+        if: inputs.run-cs-fixer
+        run: ${{ inputs.cs-fixer-command }}
+        env:
+          RUN_ENVIRONMENT: ${{ inputs.run-environment }}
+
+      - name: PHPStan
+        if: inputs.run-phpstan
+        run: ${{ inputs.phpstan-command }}
+        env:
+          RUN_ENVIRONMENT: ${{ inputs.run-environment }}
+
+      - name: XML Lint
+        if: inputs.run-xml-lint
+        run: ${{ inputs.xml-lint-command }}
+        env:
+          RUN_ENVIRONMENT: ${{ inputs.run-environment }}

--- a/.github/workflows/reusable-php-tests.yml
+++ b/.github/workflows/reusable-php-tests.yml
@@ -1,0 +1,77 @@
+name: PHP Tests
+on:
+  workflow_call:
+    inputs:
+      php-versions:
+        description: 'JSON array of PHP versions'
+        type: string
+        default: '["8.2", "8.3", "8.4", "8.5"]'
+      dependency-versions:
+        description: 'Composer dependency versions (locked/highest/lowest)'
+        type: string
+        default: 'locked'
+      test-unit-command:
+        description: 'Unit test command'
+        type: string
+        default: 'make test-unit'
+      test-integration-command:
+        description: 'Integration test command (empty to skip)'
+        type: string
+        default: ''
+      php-extensions:
+        description: 'PHP extensions to install'
+        type: string
+        default: ''
+      run-environment:
+        description: 'RUN_ENVIRONMENT value'
+        type: string
+        default: 'local'
+
+jobs:
+  tests:
+    permissions:
+      contents: read
+    name: "Tests (PHP ${{ matrix.php }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJson(inputs.php-versions) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        with:
+          coverage: none
+          php-version: "${{ matrix.php }}"
+          extensions: "${{ inputs.php-extensions }}"
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ matrix.php }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+        env:
+          COMPOSER_NO_DEV: "0"
+
+      - name: Run unit tests
+        if: inputs.test-unit-command != ''
+        run: ${{ inputs.test-unit-command }}
+        env:
+          RUN_ENVIRONMENT: ${{ inputs.run-environment }}
+
+      - name: Run integration tests
+        if: inputs.test-integration-command != ''
+        run: ${{ inputs.test-integration-command }}
+        env:
+          RUN_ENVIRONMENT: ${{ inputs.run-environment }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,96 @@
 # Build and Deployment Pipelines for TYPO3 Documentation
 
+## Reusable CI Workflows
+
+Centralized, reusable GitHub Actions workflows for repositories in the
+[TYPO3-Documentation](https://github.com/TYPO3-Documentation) organization.
+
+### Why
+
+The TYPO3-Documentation org enforces a GitHub Actions **allow-list** with
+SHA-pinned actions. This creates two maintenance challenges:
+
+1. **Composite actions break the allow-list.** Actions like
+   `ramsey/composer-install` internally call `actions/cache@v4`, which the
+   caller's allow-list must also approve. When the inner action updates its
+   SHA, all callers break silently.
+
+2. **~60 workflow files across ~29 repos** must each be updated when action
+   SHAs change, backport tooling breaks, or CI patterns evolve.
+
+Reusable workflows solve both problems: they execute in their **own**
+context (this repository), so only *this* repo's action references need to
+stay current. Callers reference a single workflow by tag/SHA and inherit
+all updates automatically.
+
+### Available Reusable Workflows
+
+| Workflow | Purpose |
+|----------|--------|
+| [`reusable-backport.yml`](.github/workflows/reusable-backport.yml) | Backport merged PRs via `korthout/backport-action` |
+| [`reusable-docs-render.yml`](.github/workflows/reusable-docs-render.yml) | Documentation rendering check |
+| [`reusable-php-quality.yml`](.github/workflows/reusable-php-quality.yml) | Code quality: CS Fixer, PHPStan, XML lint |
+| [`reusable-php-tests.yml`](.github/workflows/reusable-php-tests.yml) | PHP test matrix (unit + integration) |
+
+### Usage
+
+Call a workflow from your repository's workflow file:
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    uses: TYPO3-Documentation/t3docs-ci-deploy/.github/workflows/reusable-php-tests.yml@main
+    with:
+      php-versions: '["8.2", "8.3", "8.4"]'
+      test-unit-command: 'make test-unit'
+
+  quality:
+    uses: TYPO3-Documentation/t3docs-ci-deploy/.github/workflows/reusable-php-quality.yml@main
+    with:
+      php-version: '8.2'
+
+  docs:
+    uses: TYPO3-Documentation/t3docs-ci-deploy/.github/workflows/reusable-docs-render.yml@main
+```
+
+Backport workflow (in a separate workflow file triggered on PRs):
+
+```yaml
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    uses: TYPO3-Documentation/t3docs-ci-deploy/.github/workflows/reusable-backport.yml@main
+    with:
+      label-pattern: "backport *"
+```
+
+Each workflow accepts optional inputs with sensible defaults.
+See the individual workflow files for the full list of inputs.
+
+### Action SHA Pins
+
+All actions are SHA-pinned to verified commits. Current pins:
+
+| Action | Version | SHA |
+|--------|---------|-----|
+| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
+| `actions/cache` | v5.0.3 | `cdf6c1fa76f9f475f3d7449005a359c84ca0f306` |
+| `actions/setup-python` | v6.2.0 | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
+| `shivammathur/setup-php` | 2.36.0 | `44454db4f0199b8b9685a5d763dc37cbf79108e1` |
+| `korthout/backport-action` | v4.2.0 | `4aaf0e03a94ff0a619c9a511b61aeb42adea5b02` |
+
 ## ViewHelper Reference
 
 The Fluid ViewHelper Reference is generated automatically based on the PHP source files.


### PR DESCRIPTION
## Problem

The TYPO3-Documentation org has **~60 workflow files across ~29 repos** with identical CI patterns (backport, docs rendering, PHP tests, code quality). When action SHAs change or tooling breaks (e.g. `m-kuhn/backport@30b6e83` missing `dist/index.js`), each repo must be fixed individually.

Additionally, the org's GitHub Actions **allow-list** with SHA-pinned actions means composite actions that internally call other actions (like `ramsey/composer-install` → `actions/cache@v4`) break silently when inner SHAs change.

## Solution

Add four reusable workflows to this repository (which already serves as the org's central CI/CD hub):

| Workflow | Purpose |
|----------|---------|
| `reusable-backport.yml` | Backport merged PRs via `korthout/backport-action` |
| `reusable-docs-render.yml` | Documentation rendering check |
| `reusable-php-quality.yml` | Code quality: CS Fixer, PHPStan, XML lint |
| `reusable-php-tests.yml` | PHP test matrix (unit + integration) |

Reusable workflows execute in **this repo's context**, so only this repo's action references need to stay current. Callers reference a single workflow and inherit all updates automatically.

### Example caller (backport)

```yaml
name: Backport
on:
  pull_request_target:
    types: [closed, labeled]

jobs:
  backport:
    uses: TYPO3-Documentation/t3docs-ci-deploy/.github/workflows/reusable-backport.yml@main
    with:
      label-pattern: "backport *"
```

All actions are SHA-pinned. Each workflow accepts optional inputs with sensible defaults.

## Context

Requested by @linawolf in https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/6414#issuecomment-4039796478 — moving the workflows from [netresearch/typo3-docs-ci-workflows](https://github.com/netresearch/typo3-docs-ci-workflows) into the org's own maintenance scope.

## Benefits

- **Single point of maintenance** — update action SHAs once, all repos benefit
- **Allow-list compatible** — reusable workflows run in their own context, bypassing caller allow-list issues
- **Consistent configuration** — identical behavior across all repos
- **Faster incident response** — fix one repo instead of 29